### PR TITLE
remove trailing comma in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,5 +8,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/distantnative/footnotes"
-  },
+  }
 }


### PR DESCRIPTION
This allows the plugin to be installed via the kirby cli without an error.
#24 #28 